### PR TITLE
bugfix: create menu items

### DIFF
--- a/src/main/java/org/fenixedu/cms/ui/AdminMenuItem.java
+++ b/src/main/java/org/fenixedu/cms/ui/AdminMenuItem.java
@@ -113,7 +113,9 @@ public class AdminMenuItem {
     @RequestMapping(value = "{slugSite}/{oidMenu}/createItem", method = RequestMethod.POST)
     public RedirectView create(Model model, @PathVariable(value = "slugSite") String slugSite,
             @PathVariable(value = "oidMenu") String oidMenu, @RequestParam String menuItemOid,
-            @RequestParam LocalizedString name, @RequestParam String use, @RequestParam String url, @RequestParam String slugPage) {
+            @RequestParam LocalizedString name, @RequestParam String use,
+            @RequestParam(required = false) String url,
+            @RequestParam(required = false) String slugPage) {
         Site s = Site.fromSlug(slugSite);
 
         AdminSites.canEdit(s);

--- a/src/main/webapp/WEB-INF/fenixedu-cms/changeMenu.jsp
+++ b/src/main/webapp/WEB-INF/fenixedu-cms/changeMenu.jsp
@@ -344,8 +344,6 @@ ${portal.toolkit()}
 
     $("select[name=slugPage]").change(function(event) {
         $(event.target).closest('form').find('input[name=use].usepage').prop('checked', true);
-        var name = $(event.target).closest('form').find('input[name=name]');
-        name.val($(event.target).find(':selected').text());
     });
 </script>
   


### PR DESCRIPTION
- accepting empty fields for url and page slug.
- stop setting default name to the name of the page. The problem was on setting the name of the page to a string that should be a localized string.